### PR TITLE
use is-buffer instead of instanceof Buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
       "email": "fabian.schindler@eox.at"
     }
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "is-buffer": "^1.1.0"
+  }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,5 @@
+var isBuffer = require('is-buffer');
+
 /** 
  * Main parsing function for GeoTIFF files.
  * @param {(string|ArrayBuffer|Buffer)} data Raw data to parse the GeoTIFF from.
@@ -15,7 +17,7 @@ var parse = function(data) {
   else if (data instanceof ArrayBuffer) {
     rawData = data;
   }
-  else if (typeof Buffer !== "undefined" && data instanceof Buffer) {
+  else if (isBuffer(data)) {
     rawData = new ArrayBuffer(data.length);
     view = new Uint8Array(rawData);
     for (i=0; i<data.length; ++i) {


### PR DESCRIPTION
`instanceof Buffer` is notoriously flaky, especially in the browser where Buffer is using a user-land implementation. I couldn't get geotiff working with [drag-drop](https://npmjs.com/package/drag-drop) before, but with this patch using [is-buffer](https://npmjs.com/package/is-buffer) for feature-detection, everything works great. Plus, with this module the browser builds will be smaller since they don't need to include a `Buffer` implementation to support Buffers.
