### PR TITLE
Add Node.JS compatability

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "raster"
   ],
   "main": "src/main.js",
+  "dependencies": {
+    "xmldom": "0.1.*"
+  },
   "devDependencies": {
     "babel-preset-es2015": "^6.3.13",
     "babelify": "^7.2.0",

--- a/src/globals.js
+++ b/src/globals.js
@@ -210,11 +210,11 @@ for (key in geoKeyNames) {
   geoKeys[geoKeyNames[key]] = parseInt(key);
 }
 
-// TODO: same for node.js
 var parseXml;
 //node.js version
 if (typeof window == "undefined") {
   parseXml = function(xmlStr) {
+    //requires xlmdom module
     var DOMParser = require('xmldom').DOMParser;
     return ( new DOMParser() ).parseFromString(xmlStr, "text/xml");
   };

--- a/src/globals.js
+++ b/src/globals.js
@@ -156,7 +156,7 @@ for (key in fieldTypeNames) {
 }
 
 var geoKeyNames = {
-  1024: 'GTModelTypeGeoKey', 
+  1024: 'GTModelTypeGeoKey',
   1025: 'GTRasterTypeGeoKey',
   1026: 'GTCitationGeoKey',
   2048: 'GeographicTypeGeoKey',
@@ -212,7 +212,14 @@ for (key in geoKeyNames) {
 
 // TODO: same for node.js
 var parseXml;
-if (typeof window.DOMParser !== "undefined") {
+//node.js version
+if (typeof window == "undefined") {
+  parseXml = function(xmlStr) {
+    var DOMParser = require('xmldom').DOMParser;
+    return ( new DOMParser() ).parseFromString(xmlStr, "text/xml");
+  };
+}
+else if (typeof window.DOMParser !== "undefined") {
   parseXml = function(xmlStr) {
     return ( new window.DOMParser() ).parseFromString(xmlStr, "text/xml");
   };

--- a/src/globals.js
+++ b/src/globals.js
@@ -212,7 +212,7 @@ for (key in geoKeyNames) {
 
 var parseXml;
 //node.js version
-if (typeof window == "undefined") {
+if (typeof window === "undefined") {
   parseXml = function(xmlStr) {
     //requires xlmdom module
     var DOMParser = require('xmldom').DOMParser;


### PR DESCRIPTION
Allows geotiff.js to work easily with node.js platforms. Requires the xmldom module from npm. 

I haven't confirmed whether this change affects browser functionality because I can't get `grunt test` to work. The server runs fine but there are not TIFF files in the test directory.