### PR TITLE
Make compatible with web workers

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -32,4 +32,7 @@ if (typeof module !== "undefined" && typeof module.exports !== "undefined") {
 }
 if (typeof window !== "undefined") {
   window["GeoTIFF"] = {parse:parse};
+} else if (typeof self !== "undefined") {
+  self["GeoTIFF"] = { parse: parse };
 }
+


### PR DESCRIPTION
If geotiff.js is imported in a Web Worker the `window` global scope is not available.  Instead, this attaches GeoTIFF to the Worker Global Scope `self`.  