### PR TITLE
ignore jshint error about self being undefined

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -33,6 +33,6 @@ if (typeof module !== "undefined" && typeof module.exports !== "undefined") {
 if (typeof window !== "undefined") {
   window["GeoTIFF"] = {parse:parse};
 } else if (typeof self !== "undefined") {
-  self["GeoTIFF"] = { parse: parse };
+  self["GeoTIFF"] = { parse: parse }; // jshint ignore:line
 }
 


### PR DESCRIPTION
When I run `npm run build` I get the following jshint error:

`'self' is not defined` for line 36 in `src/main.js`

Here's a screenshot:
![jshint_error_self_undefined](https://user-images.githubusercontent.com/4313463/29753267-91843cc6-8b3b-11e7-8b3c-05b217c6bd64.png)

This pull request just adds a comment to that line telling jshint to skip this line

*Apologies in advance if I misunderstood something or I forgot to include some information