### PR TITLE
fixed missing last geokey

### DIFF
--- a/src/geotiff.js
+++ b/src/geotiff.js
@@ -175,7 +175,7 @@ GeoTIFF.prototype = {
     }
 
     var geoKeyDirectory = {};
-    for (var i = 4; i < rawGeoKeyDirectory[3] * 4; i += 4) {
+    for (var i = 4; i <= rawGeoKeyDirectory[3] * 4; i += 4) {
       var key = geoKeyNames[rawGeoKeyDirectory[i]],
         location = (rawGeoKeyDirectory[i+1]) ? (fieldTagNames[rawGeoKeyDirectory[i+1]]) : null,
         count = rawGeoKeyDirectory[i+2],

--- a/test/geotiff.spec.js
+++ b/test/geotiff.spec.js
@@ -71,6 +71,8 @@ describe("mainTests", function() {
       expect(image.getWidth()).to.equal(539);
       expect(image.getHeight()).to.equal(448);
       expect(image.getSamplesPerPixel()).to.equal(15);
+      expect(image.getGeoKeys().GeographicTypeGeoKey).to.equal(4326);
+      expect(image.getGeoKeys().GeogAngularUnitsGeoKey).to.equal(9102);
 
       try {
         var allData = image.readRasters({window: [200, 200, 210, 210]});
@@ -94,6 +96,9 @@ describe("mainTests", function() {
       expect(image.getWidth()).to.equal(539);
       expect(image.getHeight()).to.equal(448);
       expect(image.getSamplesPerPixel()).to.equal(15);
+      expect(image.getGeoKeys().GeographicTypeGeoKey).to.equal(4326);
+      expect(image.getGeoKeys().GeogAngularUnitsGeoKey).to.equal(9102);
+      expect(image.getGeoKeys().GeogInvFlatteningGeoKey).to.be.an.instanceof(Float64Array);
 
       try {
         var allData = image.readRasters({window: [200, 200, 210, 210]});
@@ -117,6 +122,9 @@ describe("mainTests", function() {
       expect(image.getWidth()).to.equal(539);
       expect(image.getHeight()).to.equal(448);
       expect(image.getSamplesPerPixel()).to.equal(15);
+      expect(image.getGeoKeys().GeographicTypeGeoKey).to.equal(4326);
+      expect(image.getGeoKeys().GeogAngularUnitsGeoKey).to.equal(9102);
+      expect(image.getGeoKeys().GeogInvFlatteningGeoKey).to.be.an.instanceof(Float64Array);
 
       try {
         var allData = image.readRasters({window: [200, 200, 210, 210]});
@@ -140,6 +148,9 @@ describe("mainTests", function() {
       expect(image.getWidth()).to.equal(539);
       expect(image.getHeight()).to.equal(448);
       expect(image.getSamplesPerPixel()).to.equal(15);
+      expect(image.getGeoKeys().GeographicTypeGeoKey).to.equal(4326);
+      expect(image.getGeoKeys().GeogAngularUnitsGeoKey).to.equal(9102);
+      expect(image.getGeoKeys().GeogInvFlatteningGeoKey).to.be.an.instanceof(Float64Array);
 
       try {
         var allData = image.readRasters({window: [200, 200, 210, 210]});
@@ -163,6 +174,9 @@ describe("mainTests", function() {
       expect(image.getWidth()).to.equal(539);
       expect(image.getHeight()).to.equal(448);
       expect(image.getSamplesPerPixel()).to.equal(15);
+      expect(image.getGeoKeys().GeographicTypeGeoKey).to.equal(4326);
+      expect(image.getGeoKeys().GeogAngularUnitsGeoKey).to.equal(9102);
+      expect(image.getGeoKeys().GeogInvFlatteningGeoKey).to.be.an.instanceof(Float64Array);
 
       try {
         var allData = image.readRasters({window: [200, 200, 210, 210]});
@@ -186,6 +200,9 @@ describe("mainTests", function() {
       expect(image.getWidth()).to.equal(539);
       expect(image.getHeight()).to.equal(448);
       expect(image.getSamplesPerPixel()).to.equal(15);
+      expect(image.getGeoKeys().GeographicTypeGeoKey).to.equal(4326);
+      expect(image.getGeoKeys().GeogAngularUnitsGeoKey).to.equal(9102);
+      expect(image.getGeoKeys().GeogInvFlatteningGeoKey).to.be.an.instanceof(Float64Array);
 
       try {
         var allData = image.readRasters({window: [200, 200, 210, 210]});
@@ -209,6 +226,9 @@ describe("mainTests", function() {
       expect(image.getWidth()).to.equal(539);
       expect(image.getHeight()).to.equal(448);
       expect(image.getSamplesPerPixel()).to.equal(15);
+      expect(image.getGeoKeys().GeographicTypeGeoKey).to.equal(4326);
+      expect(image.getGeoKeys().GeogAngularUnitsGeoKey).to.equal(9102);
+      expect(image.getGeoKeys().GeogInvFlatteningGeoKey).to.be.an.instanceof(Float64Array);
 
       try {
         var allData = image.readRasters({window: [200, 200, 210, 210]});
@@ -232,6 +252,9 @@ describe("mainTests", function() {
       expect(image.getWidth()).to.equal(539);
       expect(image.getHeight()).to.equal(448);
       expect(image.getSamplesPerPixel()).to.equal(15);
+      expect(image.getGeoKeys().GeographicTypeGeoKey).to.equal(4326);
+      expect(image.getGeoKeys().GeogAngularUnitsGeoKey).to.equal(9102);
+      expect(image.getGeoKeys().GeogInvFlatteningGeoKey).to.be.an.instanceof(Float64Array);
 
       try {
         var allData = image.readRasters({window: [200, 200, 210, 210]});
@@ -255,6 +278,9 @@ describe("mainTests", function() {
       expect(image.getWidth()).to.equal(539);
       expect(image.getHeight()).to.equal(448);
       expect(image.getSamplesPerPixel()).to.equal(15);
+      expect(image.getGeoKeys().GeographicTypeGeoKey).to.equal(4326);
+      expect(image.getGeoKeys().GeogAngularUnitsGeoKey).to.equal(9102);
+      expect(image.getGeoKeys().GeogInvFlatteningGeoKey).to.be.an.instanceof(Float64Array);
 
       try {
         var allData = image.readRasters({window: [200, 200, 210, 210]});
@@ -278,6 +304,10 @@ describe("mainTests", function() {
       expect(image.getWidth()).to.equal(539);
       expect(image.getHeight()).to.equal(448);
       expect(image.getSamplesPerPixel()).to.equal(15);
+      expect(image.getGeoKeys().GeographicTypeGeoKey).to.equal(4326);
+      expect(image.getGeoKeys().GeogAngularUnitsGeoKey).to.equal(9102);
+      expect(image.getGeoKeys().GeogInvFlatteningGeoKey).to.be.an.instanceof(Float64Array);
+
 
       try {
         var allData = image.readRasters({window: [200, 200, 210, 210]});
@@ -301,6 +331,9 @@ describe("mainTests", function() {
       expect(image.getWidth()).to.equal(539);
       expect(image.getHeight()).to.equal(448);
       expect(image.getSamplesPerPixel()).to.equal(15);
+      expect(image.getGeoKeys().GeographicTypeGeoKey).to.equal(4326);
+      expect(image.getGeoKeys().GeogAngularUnitsGeoKey).to.equal(9102);
+      expect(image.getGeoKeys().GeogInvFlatteningGeoKey).to.be.an.instanceof(Float64Array);
 
       try {
         var allData = image.readRasters({window: [200, 200, 210, 210]});
@@ -485,6 +518,8 @@ describe("RGB-tests", function() {
       expect(image.getResolution()).to.be.an('array');
       expect(image.getOrigin()).to.be.an('array');
       expect(image.getBoundingBox()).to.be.an('array');
+      expect(image.getGeoKeys()).to.have.property("GeographicTypeGeoKey");
+      expect(image.getGeoKeys().GeographicTypeGeoKey).to.equal(4326);
       done();
     });
   });


### PR DESCRIPTION
Adjusted `parseGeoKeyDirectory`, so it parses the last GeoKey.  Missing the last GeoKey isn't really a big issue for thoroughly tagged geotiffs, because the last key is often something like `GeogInvFlatteningGeoKey`.  However, I've been trying to integrate with exports from geoserver via WCS, which often put `GeographicTypeGeoKey` as the last key.  Here's an example from geoserver:
http://geomap.arpa.veneto.it/geoserver/wcs?crs=EPSG%3A4326&service=WCS&format=GeoTIFF&request=GetCoverage&height=329&width=368&version=1.0.0&BBox=9.679858245722988%2C13.951082737884812%2C44.183855724634675%2C47.38727409375604&Coverage=geonode%3Aatlanteil

Link to a downloaded version on S3 if the above link doesn't work for you: https://s3.amazonaws.com/georaster/geonode_atlanteil.tif

As always, let me know if there's anything I missed or should improve on my PR :-)

Thanks!